### PR TITLE
feat: add support for network policy

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -54,8 +54,10 @@ jobs:
         run: ct lint --config ct.yaml --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.4.0
+        with:
+          config: kind-cluster.yaml
 
       - name: Install Calico
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -64,12 +64,6 @@ jobs:
           kubectl -n kube-system rollout status daemonset/calico-node --timeout=120s
           kubectl -n kube-system rollout status deployment calico-kube-controllers --timeout=120s
 
-      - name: Install ingress-nginx
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-          kubectl -n ingress-nginx rollout status deployment ingress-nginx-controller --timeout 120s
-
       - name: Fix CoreDNS upstream resolver
         if: steps.list-changed.outputs.changed == 'true'
         run: |

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
           check-latest: true
 
       # - name: Run helm lint
@@ -56,6 +56,19 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Install Calico
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
+          kubectl -n kube-system rollout status daemonset/calico-node --timeout=120s
+          kubectl -n kube-system rollout status deployment calico-kube-controllers --timeout=120s
+
+      - name: Install ingress-nginx
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          kubectl -n ingress-nginx rollout status deployment ingress-nginx-controller --timeout 120s
 
       - name: Fix CoreDNS upstream resolver
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/kind-cluster.yaml
+++ b/kind-cluster.yaml
@@ -1,0 +1,20 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -149,6 +149,7 @@ Check that the deployed pods are all running.
 | `initialAccount.existingSecretPasswordKey` | Name of the key in the existing secret to use for the initial account's password                                                       | `""`             |
 | `initialAccount.mode`                      | How to treat the creationg of the initial account. Possible values: "create", "update" or "ifmissing"                                  | `update`         |
 | `subnet`                                   | Change this if you're using different address ranges for pods                                                                          | `10.42.0.0/16`   |
+| `networkPolicy.enabled`                    | Enable network policy                                                                                                                  | `false`          |
 | `mailuVersion`                             | Version/tag of mailu images - must be master or a version >= 1.9                                                                       | `1.9.39`         |
 | `logLevel`                                 | default log level. can be overridden globally or per service                                                                           | `WARNING`        |
 | `postmaster`                               | local part of the postmaster email address (Mailu will use @$DOMAIN as domain part)                                                    | `postmaster`     |

--- a/mailu/ci/helm-lint-values.yaml
+++ b/mailu/ci/helm-lint-values.yaml
@@ -11,7 +11,10 @@ initialAccount:
 
 secretKey: chang3m3!
 
-subnet: 10.0.0.0/8
+subnet: 192.168.0.0/16
+
+networkPolicy:
+  enabled: true
 
 persistence:
   single_pvc: false

--- a/mailu/templates/network-policies.yaml
+++ b/mailu/templates/network-policies.yaml
@@ -1,0 +1,107 @@
+{{- if and .Values.networkPolicy.enabled }}
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-default-deny" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-egress-all" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}
+---
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-front" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: front
+  ingress:
+    # Allow ports 25/TCP, 80/TCP, 110/TCP, 143/TCP, 443/TCP, 465/TCP, 587/TCP, 995/TCP, 993/TCP
+    - ports:
+      - port: 25
+        protocol: TCP
+      - port: 80
+        protocol: TCP
+      - port: 110
+        protocol: TCP
+      - port: 143
+        protocol: TCP
+      - port: 443
+        protocol: TCP
+      - port: 465
+        protocol: TCP
+      - port: 587
+        protocol: TCP
+      - port: 995
+        protocol: TCP
+      - port: 993
+        protocol: TCP
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-internal" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/mailu/templates/network-policies.yaml
+++ b/mailu/templates/network-policies.yaml
@@ -34,7 +34,8 @@ metadata:
   {{- end }}
 spec:
   podSelector:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
     - Egress
   egress:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -88,6 +88,10 @@ initialAccount:
 ## @param subnet Change this if you're using different address ranges for pods
 subnet: 10.42.0.0/16
 
+## @param networkPolicy.enabled Enable network policy
+networkPolicy:
+  enabled: false
+
 ## @param mailuVersion Version/tag of mailu images - must be master or a version >= 1.9
 mailuVersion: 1.9.39
 


### PR DESCRIPTION
This PR adds support to enable `NetworkPolicy` for Mailu pods.

This setting is disabled by default and needs to be enabled via:
```yaml
networkPolicy:
  enabled: true
```

By default, this will:
- deny all inbound traffic to Mailu pods
- allow all outbound traffic from Mailu pods
- allow all traffic between Mailu pods
- allow inbound traffic to Mailu `front` pod on the following ports: 25/TCP, 80/TCP, 110/TCP, 143/TCP, 443/TCP, 465/TCP, 587/TCP, 995/TCP, 993/TCP

