### PR TITLE
Refactor env vars

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -25,12 +25,12 @@ Branches exists for older mailu versions (e.g. old/mailu-1.8).
 - A hosting service that allows inbound and outbound traffic on port 25.
 - Helm 3 (helm 2 support is dropped with release 0.3.0).
 
-| Repository | Name | Version |
-|------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.0.3 |
-| https://charts.bitnami.com/bitnami | mariadb | 11.3.* |
-| https://charts.bitnami.com/bitnami | postgresql | 11.9.* |
-| https://charts.bitnami.com/bitnami | redis | 17.3.* |
+| Repository                         | Name       | Version |
+| ---------------------------------- | ---------- | ------- |
+| https://charts.bitnami.com/bitnami | common     | 2.0.3   |
+| https://charts.bitnami.com/bitnami | mariadb    | 11.3.\* |
+| https://charts.bitnami.com/bitnami | postgresql | 11.9.\* |
+| https://charts.bitnami.com/bitnami | redis      | 17.3.\* |
 
 ### Warning about open relays
 
@@ -121,7 +121,6 @@ Check that the deployed pods are all running.
 | `global.database.roundcube.existingSecret`            | Name of an existing secret to use for the roundcube database                      | `""`        |
 | `global.database.roundcube.existingSecretPasswordKey` | Name of the key in the existing secret to use for the roundcube database password | `""`        |
 
-
 ### Common parameters
 
 | Name                | Description                                                                          | Value |
@@ -131,7 +130,6 @@ Check that the deployed pods are all running.
 | `fullnameOverride`  | String to fully override mailu.fullname template                                     | `""`  |
 | `commonLabels`      | Add labels to all the deployed resources                                             | `{}`  |
 | `commonAnnotations` | Add annotations to all the deployed resources                                        | `{}`  |
-
 
 ### Mailu parameters
 
@@ -162,12 +160,12 @@ Check that the deployed pods are all running.
 | `limits.authRatelimit.exemption`           | Sets the `AUTH_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                            | `""`             |
 | `limits.messageRatelimit.value`            | Sets the `MESSAGE_RATELIMIT` environment variable in the `admin` pod                                                                   | `200/day`        |
 | `limits.messageRatelimit.exemption`        | Sets the `MESSAGE_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                         | `""`             |
-| `external_relay.host`                      | Hostname of the external relay                                                                                                         | `""`             |
-| `external_relay.username`                  | Username for the external relay                                                                                                        | `""`             |
-| `external_relay.password`                  | Password for the external relay                                                                                                        | `""`             |
-| `external_relay.secretName`                | Name of the secret containing the username and password for the external relay; if set, username and password will be ignored          | `""`             |
-| `external_relay.usernameKey`               | Key in the secret containing the username for the external relay                                                                       | `relay-username` |
-| `external_relay.passwordKey`               | Key in the secret containing the password for the external relay                                                                       | `relay-password` |
+| `externalRelay.host`                       | Hostname of the external relay                                                                                                         | `""`             |
+| `externalRelay.username`                   | Username for the external relay                                                                                                        | `""`             |
+| `externalRelay.password`                   | Password for the external relay                                                                                                        | `""`             |
+| `externalRelay.secretName`                 | Name of the secret containing the username and password for the external relay; if set, username and password will be ignored          | `""`             |
+| `externalRelay.usernameKey`                | Key in the secret containing the username for the external relay                                                                       | `relay-username` |
+| `externalRelay.passwordKey`                | Key in the secret containing the password for the external relay                                                                       | `relay-password` |
 | `clusterDomain`                            | Kubernetes cluster domain name                                                                                                         | `cluster.local`  |
 | `credentialRounds`                         | Number of rounds to use for password hashing                                                                                           | `12`             |
 | `sessionCookieSecure`                      | Controls the secure flag on the cookies of the administrative interface.                                                               | `true`           |
@@ -176,7 +174,6 @@ Check that the deployed pods are all running.
 | `letsencryptShortchain`                    | Controls whether we send the ISRG Root X1 certificate in TLS handshakes.                                                               | `false`          |
 | `tolerations`                              | Tolerations for pod assignment                                                                                                         | `[]`             |
 | `affinity`                                 | Affinity for pod assignment                                                                                                            | `{}`             |
-
 
 ### Storage parameters
 
@@ -236,7 +233,6 @@ Check that the deployed pods are all running.
 | `persistence.storageClass`                          | Storage class of backing PVC (for single PVC)                                                                                                                                                             | `""`                   |
 | `persistence.claimNameOverride`                     | Override the name of the PVC (for single PVC)                                                                                                                                                             | `""`                   |
 
-
 ### Ingress settings
 
 | Name                        | Description                                                                                                                      | Value                    |
@@ -258,7 +254,6 @@ Check that the deployed pods are all running.
 | `ingress.realIpHeader`      | Sets the value of `REAL_IP_HEADER` environment variable in the `front` pod                                                       | `X-Forwarded-For`        |
 | `ingress.realIpFrom`        | Sets the value of `REAL_IP_FROM` environment variable in the `front` pod                                                         | `0.0.0.0/0`              |
 | `ingress.tlsFlavorOverride` | Overrides the value of `TLS_FLAVOR` environment variable in the `front` pod                                                      | `""`                     |
-
 
 ### Frontend load balancer for non-HTTP(s) services
 
@@ -323,7 +318,6 @@ Check that the deployed pods are all running.
 | `front.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`            |
 | `front.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`            |
 
-
 ### Admin parameters
 
 | Name                                       | Description                                                                           | Value               |
@@ -377,7 +371,6 @@ Check that the deployed pods are all running.
 | `admin.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `admin.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
-
 ### Redis parameters
 
 | Name                                     | Description                                                         | Value               |
@@ -395,7 +388,6 @@ Check that the deployed pods are all running.
 | `redis.master.persistence.existingClaim` | Pod pvc existing claim; necessary if using single_pvc               | `""`                |
 | `redis.master.persistence.subPath`       | Subpath in PVC; necessary if using single_pvc (set it to `/redis`)  | `""`                |
 | `redis.replica.count`                    | Number of redis replicas (only if `redis.architecture=replication`) | `0`                 |
-
 
 ### Postfix parameters
 
@@ -450,7 +442,6 @@ Check that the deployed pods are all running.
 | `postfix.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `postfix.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 | `postfix.overrides`                          | Enable postfix overrides                                                              | `{}`                |
-
 
 ### Dovecot parameters
 
@@ -509,7 +500,6 @@ Check that the deployed pods are all running.
 | `dovecot.compression`                        | Maildir compression algorithm (gz, bz2, lz4, zstd)                                    | `""`                |
 | `dovecot.compressionLevel`                   | Maildir compression level (1-9)                                                       | `6`                 |
 
-
 ### rspamd parameters
 
 | Name                                        | Description                                                                           | Value               |
@@ -563,7 +553,6 @@ Check that the deployed pods are all running.
 | `rspamd.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `rspamd.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 | `rspamd.overrides`                          | Enable rspamd overrides                                                               | `{}`                |
-
 
 ### clamav parameters
 
@@ -622,7 +611,6 @@ Check that the deployed pods are all running.
 | `clamav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `clamav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
-
 ### webmail parameters
 
 | Name                                         | Description                                                                           | Value               |
@@ -679,7 +667,6 @@ Check that the deployed pods are all running.
 | `webmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `webmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
-
 ### webdav parameters
 
 | Name                                        | Description                                                                           | Value               |
@@ -733,7 +720,6 @@ Check that the deployed pods are all running.
 | `webdav.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
 | `webdav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `webdav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
-
 
 ### fetchmail parameters
 
@@ -789,7 +775,6 @@ Check that the deployed pods are all running.
 | `fetchmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
 | `fetchmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `fetchmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
-
 
 ## Example values.yaml to get started
 
@@ -947,3 +932,92 @@ If you run on bare metal with k3s (e.g by using k3os), you can use the build-in 
 The [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) is important to preserve the client's source IP and avoid an open relay.
 
 Please perform open relay tests after setup as described above!
+
+## Environment variables mapping
+
+The table below lists the environment variables that will be passed to the pods and their respective configuration path in the `values.yaml` file.
+
+| Mailu env var                     | `values.yaml` config path              | Comment                                                    | Default value (Mailu 'docker' version)                   | Helm default value                                                                               |
+| --------------------------------- | -------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `ADMIN`                           | `admin.enabled`                        |                                                            | `none`                                                   | `true`                                                                                           |
+| `ANTIVIRUS_ACTION`                | `rspamd.antivirusAction`               |                                                            | `discard`                                                | `discard`                                                                                        |
+| `AUTH_RATELIMIT_EXEMPTION_LENGTH` | `limits.authRatelimit.exemptionLength` |                                                            | `86400`                                                  | `86400`                                                                                          |
+| `AUTH_RATELIMIT_EXEMPTION`        | `limits.authRatelimit.exemption`       |                                                            | ``                                                       | ``                                                                                               |
+| `AUTH_RATELIMIT_IP`               | `limits.authRatelimit.ip`              |                                                            | `60/hour`                                                | `60/hour`                                                                                        |
+| `AUTH_RATELIMIT_IP_V4_MASK`       | `limits.authRatelimit.ipv4Mask`        |                                                            | `24`                                                     | `24`                                                                                             |
+| `AUTH_RATELIMIT_IP_V6_MASK`       | `limits.authRatelimit.ipv6Mask`        |                                                            | `56`                                                     | `56`                                                                                             |
+| `AUTH_RATELIMIT_USER`             | `limits.authRatelimit.user`            |                                                            | `100/day`                                                | `100/day`                                                                                        |
+| `BABEL_DEFAULT_LOCALE`            | -                                      |                                                            | `en`                                                     | `en`                                                                                             |
+| `BABEL_DEFAULT_TIMEZONE`          | -                                      |                                                            | `UTC`                                                    | `UTC`                                                                                            |
+| `BOOTSTRAP_SERVE_LOCAL`           | -                                      |                                                            | `True`                                                   | `True`                                                                                           |
+| `CREDENTIAL_ROUNDS`               | `credentialRounds`                     |                                                            | `12`                                                     | `12`                                                                                             |
+| `DB_FLAVOR`                       |                                        | Managed by Helm chart                                      | None                                                     |                                                                                                  |
+| `DB_HOST`                         |                                        | Managed by Helm chart                                      | database                                                 |                                                                                                  |
+| `DB_NAME`                         |                                        | Managed by Helm chart                                      | mailu                                                    |                                                                                                  |
+| `DB_PW`                           |                                        | Managed by Helm chart                                      | None                                                     |                                                                                                  |
+| `DB_USER`                         |                                        | Managed by Helm chart                                      | mailu                                                    |                                                                                                  |
+| `DEBUG_ASSETS`                    | -                                      |                                                            | ``                                                       |                                                                                                  |
+| `DEBUG`                           | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `DEBUG_PROFILER`                  | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `DEBUG_TB_INTERCEPT_REDIRECTS`    | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `DEFAULT_QUOTA`                   | -                                      |                                                            | `1000000000`                                             | `1000000000`                                                                                     |
+| `DEFAULT_SPAM_THRESHOLD`          | -                                      |                                                            | `80`                                                     | `80`                                                                                             |
+| `DEFER_ON_TLS_ERROR`              | -                                      |                                                            | `True`                                                   | `true`                                                                                           |
+| `DISABLE_STATISTICS`              | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `DKIM_PATH`                       | -                                      |                                                            | `/dkim/{domain}.{selector}.key`                          | `/dkim/{domain}.{selector}.key`                                                                  |
+| `DKIM_SELECTOR`                   | -                                      |                                                            | `dkim`                                                   | `dkim`                                                                                           |
+| `DMARC_RUA`                       | `dmarc.rua`                            |                                                            | `none`                                                   | `none`                                                                                           |
+| `DMARC_RUF`                       | `dmarc.ruf`                            |                                                            | `none`                                                   | `none`                                                                                           |
+| `DOCKER_SOCKET`                   | -                                      | Not set in Helm Chart                                      | `unix:///var/run/docker.sock`                            | -                                                                                                |
+| `DOMAIN`                          | `domain`                               |                                                            | `mailu.io`                                               | _unset_                                                                                          |
+| `DOMAIN_REGISTRATION`             | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `FETCHMAIL_ENABLED`               | `fetchmail.enabled`                    |                                                            | `False`                                                  | `false`                                                                                          |
+| `HOSTNAMES`                       | `hostnames`                            | Use an array in Helm values instead of a string            | `mail.mailu.io,alternative.mailu.io,yetanother.mailu.io` | `[]`                                                                                             |
+| `INBOUND_TLS_ENFORCE`             | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `INSTANCE_ID_PATH`                | -                                      |                                                            | `/data/instance`                                         | `/data/instance`                                                                                 |
+| `KUBERNETES_INGRESS`              | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `LOG_LEVEL`                       | `logLevel`                             | Can be overriden for each pod through `COMPONENT.logLevel` | `WARNING`                                                | `WARNING`                                                                                        |
+| `LOGO_BACKGROUND`                 | `customization.logoBackground`         |                                                            | `None`                                                   | `none`                                                                                           |
+| `LOGO_URL`                        | `customization.logoUrl`                |                                                            | `None`                                                   | `none`                                                                                           |
+| `MEMORY_SESSIONS`                 | `ingress.enabled`                      |                                                            | `False`                                                  | `true`                                                                                           |
+| `MESSAGE_RATELIMIT_EXEMPTION`     | `limits.messageRatelimit.exemption`    |                                                            | ``                                                       | ``                                                                                               |
+| `MESSAGE_RATELIMIT`               | `limits.messageRatelimit.value`        |                                                            | `200/day`                                                | `200/day`                                                                                        |
+| `PERMANENT_SESSION_LIFETIME`      | `permanentSessionLifetime`             |                                                            | `30*24*3600`                                             | `108000`                                                                                         |
+| `POSTMASTER`                      | `postmaster`                           |                                                            | `postmaster`                                             | `postmaster`                                                                                     |
+| `PROXY_AUTH_CREATE`               | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `PROXY_AUTH_HEADER`               | -                                      |                                                            | `X-Auth-Email`                                           | `X-Auth-Email`                                                                                   |
+| `PROXY_AUTH_WHITELIST`            | -                                      |                                                            | ``                                                       | ``                                                                                               |
+| `RATELIMIT_STORAGE_URL`           | -                                      | Managed by Helm chart                                      | ``                                                       |                                                                                                  |
+| `RECAPTCHA_PRIVATE_KEY`           | -                                      |                                                            | ``                                                       | ``                                                                                               |
+| `RECAPTCHA_PUBLIC_KEY`            | -                                      |                                                            | ``                                                       | ``                                                                                               |
+| `REAL_IP_FROM`                    | `ingress.realIpFrom`                   |                                                            | ``                                                       | `0.0.0.0/0`                                                                                      |
+| `REAL_IP_HEADER`                  | `ingress.realIpHeader`                 |                                                            | ``                                                       | `X-Forwarded-For`                                                                                |
+| `RECIPIENT_DELIMITER`             | `recipientDelimiter`                   |                                                            | ``                                                       | `+`                                                                                              |
+| `REJECT_UNLISTED_RECIPIENT`       | -                                      |                                                            | `yes`                                                    | `yes`                                                                                            |
+| `RELAYHOST`                       | `externalRealy.host`                   |                                                            | ``                                                       | ``                                                                                               |
+| `RELAYNETS`                       | `externalRealy.networks`               |                                                            | ``                                                       | ``                                                                                               |
+| `ROUNDCUBE_DB_FLAVOR`             | -                                      | Managed by Helm chart                                      | `sqlite`                                                 | ``                                                                                               |
+| `SECRET_KEY`                      | `secretKey` or `existingSecret`        | Auto-generated if not provided or empty                    | `changeMe`                                               | _auto-generated_                                                                                 |
+| `SESSION_COOKIE_SECURE`           | `sessionCookieSecure`                  |                                                            | `None`                                                   | `true`                                                                                           |
+| `SESSION_KEY_BITS`                | -                                      |                                                            | `128`                                                    | `128`                                                                                            |
+| `SESSION_TIMEOUT`                 | `sessionTimeout`                       |                                                            | `3600`                                                   | `3600`                                                                                           |
+| `SITENAME`                        | `customization.siteName`               |                                                            | `Mailu`                                                  | `Mailu`                                                                                          |
+| `SQLALCHEMY_DATABASE_URI`         | -                                      |                                                            | `sqlite:////data/main.db`                                | `sqlite:////data/main.db`                                                                        |
+| `SQLALCHEMY_TRACK_MODIFICATIONS`  | -                                      |                                                            | `False`                                                  | `false`                                                                                          |
+| `SQLITE_DATABASE_FILE`            | -                                      |                                                            | `data/main.db`                                           | `data/main.db`                                                                                   |
+| `STATS_ENDPOINT`                  | -                                      |                                                            | `19.{}.stats.mailu.io`                                   | `19.{}.stats.mailu.io`                                                                           |
+| `SUBNET6`                         | `subnet6`                              | _warning: IPv6 support with Kubernetes is untested_        | `None`                                                   | `none`                                                                                           |
+| `SUBNET`                          | `subnet`                               |                                                            | `192.168.203.0/24`                                       | `10.42.0.0/16`                                                                                   |
+| `TEMPLATES_AUTO_RELOAD`           | -                                      |                                                            | `True`                                                   | `True`                                                                                           |
+| `TLS_FLAVOR`                      | `ingress.tlsFlavorOverride`            |                                                            | `cert`                                                   | `cert`                                                                                           |
+| `TLS_PERMISSIVE`                  | -                                      |                                                            | `True`                                                   | `True`                                                                                           |
+| `TZ`                              | `timezone`                             |                                                            | `Etc/UTC`                                                | `Etc/UTC`                                                                                        |
+| `WEB_ADMIN`                       | `admin.uri`                            |                                                            | `/admin`                                                 | `/admin`                                                                                         |
+| `WEBMAIL`                         | `webmail.type`                         |                                                            | `none`                                                   | `roundcube`                                                                                      |
+| `WEBSITE`                         | `customization.website`                |                                                            | `https://mailu.io`                                       | `https://mailu.io`                                                                               |
+| `WEB_WEBMAIL`                     | `webmail.uri`                          |                                                            | `/webmail`                                               | `/webmail`                                                                                       |
+| `WELCOME`                         | `welcomeMessage.enabled`               |                                                            | `False`                                                  | `false`                                                                                          |
+| `WELCOME_BODY`                    | `welcomeMessage.body`                  |                                                            | `Dummy welcome body`                                     | `Welcome to Mailu, your new email service. Please change your password and update your profile.` |
+| `WELCOME_SUBJECT`                 | `welcomeMessage.subject`               |                                                            | `Dummy welcome topic`                                    | `Welcome to Mailu`                                                                               |
+| `WILDCARD_SENDERS`                | -                                      |                                                            | ``                                                       | ``                                                                                               |
+| `*_ADDRESS`                       | -                                      | Auto-generated by Helm chart                               | ``                                                       | ``                                                                                               |

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -121,6 +121,7 @@ Check that the deployed pods are all running.
 | `global.database.roundcube.existingSecret`            | Name of an existing secret to use for the roundcube database                      | `""`        |
 | `global.database.roundcube.existingSecretPasswordKey` | Name of the key in the existing secret to use for the roundcube database password | `""`        |
 
+
 ### Common parameters
 
 | Name                | Description                                                                          | Value |
@@ -130,50 +131,65 @@ Check that the deployed pods are all running.
 | `fullnameOverride`  | String to fully override mailu.fullname template                                     | `""`  |
 | `commonLabels`      | Add labels to all the deployed resources                                             | `{}`  |
 | `commonAnnotations` | Add annotations to all the deployed resources                                        | `{}`  |
+| `tolerations`       | Tolerations for pod assignment                                                       | `[]`  |
+| `affinity`          | Affinity for pod assignment                                                          | `{}`  |
+
 
 ### Mailu parameters
 
-| Name                                       | Description                                                                                                                            | Value            |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `hostnames`                                | List of hostnames to generate certificates and ingresses for. The first will be used as primary mail hostname.                         | `[]`             |
-| `domain`                                   | Mail domain name. See https://github.com/Mailu/Mailu/blob/master/docs/faq.rst#what-is-the-difference-between-domain-and-hostnames      | `""`             |
-| `secretKey`                                | The secret key is required for protecting authentication cookies and must be set individually for each deployment                      | `""`             |
-| `existingSecret`                           | Name of the existing secret to retrieve the secretKey.                                                                                 | `""`             |
-| `initialAccount.enabled`                   | Enable the creation of the initial account                                                                                             | `false`          |
-| `initialAccount.username`                  | Username of the initial account                                                                                                        | `""`             |
-| `initialAccount.domain`                    | Domain of the initial account                                                                                                          | `""`             |
-| `initialAccount.password`                  | Password of the initial account; ignored if using existing secret; if empty, a random password will be generated and saved in a secret | `""`             |
-| `initialAccount.existingSecret`            | Name of the existing secret to retrieve the initial account's password                                                                 | `""`             |
-| `initialAccount.existingSecretPasswordKey` | Name of the key in the existing secret to use for the initial account's password                                                       | `""`             |
-| `initialAccount.mode`                      | How to treat the creationg of the initial account. Possible values: "create", "update" or "ifmissing"                                  | `update`         |
-| `subnet`                                   | Change this if you're using different address ranges for pods                                                                          | `10.42.0.0/16`   |
-| `networkPolicy.enabled`                    | Enable network policy                                                                                                                  | `false`          |
-| `mailuVersion`                             | Version/tag of mailu images - must be master or a version >= 1.9                                                                       | `1.9.39`         |
-| `logLevel`                                 | default log level. can be overridden globally or per service                                                                           | `WARNING`        |
-| `postmaster`                               | local part of the postmaster email address (Mailu will use @$DOMAIN as domain part)                                                    | `postmaster`     |
-| `limits.messageSizeLimitInMegabytes`       | Maximum size of an email in megabytes                                                                                                  | `50`             |
-| `limits.authRatelimit.ip`                  | Sets the `AUTH_RATELIMIT_IP` environment variable in the `admin` pod                                                                   | `60/hour`        |
-| `limits.authRatelimit.ipv4Mask`            | Sets the `AUTH_RATELIMIT_IP_V4_MASK` environment variable in the `admin` pod                                                           | `24`             |
-| `limits.authRatelimit.ipv6Mask`            | Sets the `AUTH_RATELIMIT_IP_V6_MASK` environment variable in the `admin` pod                                                           | `56`             |
-| `limits.authRatelimit.user`                | Sets the `AUTH_RATELIMIT_USER` environment variable in the `admin` pod                                                                 | `100/day`        |
-| `limits.authRatelimit.exemptionLength`     | Sets the `AUTH_RATELIMIT_EXEMPTION_LENGTH` environment variable in the `admin` pod                                                     | `86400`          |
-| `limits.authRatelimit.exemption`           | Sets the `AUTH_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                            | `""`             |
-| `limits.messageRatelimit.value`            | Sets the `MESSAGE_RATELIMIT` environment variable in the `admin` pod                                                                   | `200/day`        |
-| `limits.messageRatelimit.exemption`        | Sets the `MESSAGE_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                         | `""`             |
-| `externalRelay.host`                       | Hostname of the external relay                                                                                                         | `""`             |
-| `externalRelay.username`                   | Username for the external relay                                                                                                        | `""`             |
-| `externalRelay.password`                   | Password for the external relay                                                                                                        | `""`             |
-| `externalRelay.secretName`                 | Name of the secret containing the username and password for the external relay; if set, username and password will be ignored          | `""`             |
-| `externalRelay.usernameKey`                | Key in the secret containing the username for the external relay                                                                       | `relay-username` |
-| `externalRelay.passwordKey`                | Key in the secret containing the password for the external relay                                                                       | `relay-password` |
-| `clusterDomain`                            | Kubernetes cluster domain name                                                                                                         | `cluster.local`  |
-| `credentialRounds`                         | Number of rounds to use for password hashing                                                                                           | `12`             |
-| `sessionCookieSecure`                      | Controls the secure flag on the cookies of the administrative interface.                                                               | `true`           |
-| `sessionTimeout`                           | Maximum amount of time in seconds between requests before a session is invalidated                                                     | `3600`           |
-| `permanentSessionLifetime`                 | Maximum amount of time in seconds a session can be kept alive for if it hasn’t timed-out                                               | `108000`         |
-| `letsencryptShortchain`                    | Controls whether we send the ISRG Root X1 certificate in TLS handshakes.                                                               | `false`          |
-| `tolerations`                              | Tolerations for pod assignment                                                                                                         | `[]`             |
-| `affinity`                                 | Affinity for pod assignment                                                                                                            | `{}`             |
+| Name                                       | Description                                                                                                                            | Value                                                                                            |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `hostnames`                                | List of hostnames to generate certificates and ingresses for. The first will be used as primary mail hostname.                         | `[]`                                                                                             |
+| `domain`                                   | Mail domain name. See https://github.com/Mailu/Mailu/blob/master/docs/faq.rst#what-is-the-difference-between-domain-and-hostnames      | `""`                                                                                             |
+| `secretKey`                                | The secret key is required for protecting authentication cookies and must be set individually for each deployment                      | `""`                                                                                             |
+| `existingSecret`                           | Name of the existing secret to retrieve the secretKey.                                                                                 | `""`                                                                                             |
+| `timezone`                                 | Timezone to use for the containers                                                                                                     | `Etc/UTC`                                                                                        |
+| `initialAccount.enabled`                   | Enable the creation of the initial account                                                                                             | `false`                                                                                          |
+| `initialAccount.username`                  | Username of the initial account                                                                                                        | `""`                                                                                             |
+| `initialAccount.domain`                    | Domain of the initial account                                                                                                          | `""`                                                                                             |
+| `initialAccount.password`                  | Password of the initial account; ignored if using existing secret; if empty, a random password will be generated and saved in a secret | `""`                                                                                             |
+| `initialAccount.existingSecret`            | Name of the existing secret to retrieve the initial account's password                                                                 | `""`                                                                                             |
+| `initialAccount.existingSecretPasswordKey` | Name of the key in the existing secret to use for the initial account's password                                                       | `""`                                                                                             |
+| `initialAccount.mode`                      | How to treat the creationg of the initial account. Possible values: "create", "update" or "ifmissing"                                  | `update`                                                                                         |
+| `subnet`                                   | Change this if you're using different address ranges for pods (IPv4)                                                                   | `10.42.0.0/16`                                                                                   |
+| `subnet6`                                  | Change this if you're using different address ranges for pods (IPv6)                                                                   | `none`                                                                                           |
+| `networkPolicy.enabled`                    | Enable network policy                                                                                                                  | `false`                                                                                          |
+| `mailuVersion`                             | Version/tag of mailu images - must be master or a version >= 1.9                                                                       | `1.9.39`                                                                                         |
+| `logLevel`                                 | default log level. can be overridden globally or per service                                                                           | `WARNING`                                                                                        |
+| `postmaster`                               | local part of the postmaster email address (Mailu will use @$DOMAIN as domain part)                                                    | `postmaster`                                                                                     |
+| `recipientDelimiter`                       | The delimiter used to separate local part from extension in recipient addresses                                                        | `+`                                                                                              |
+| `dmarc.rua`                                | Local part of the DMARC report email address (Mailu will use @$DOMAIN as domain part)                                                  | `none`                                                                                           |
+| `dmarc.ruf`                                | Local part of the DMARC failure report email address (Mailu will use @$DOMAIN as domain part)                                          | `none`                                                                                           |
+| `limits.messageSizeLimitInMegabytes`       | Maximum size of an email in megabytes                                                                                                  | `50`                                                                                             |
+| `limits.authRatelimit.ip`                  | Sets the `AUTH_RATELIMIT_IP` environment variable in the `admin` pod                                                                   | `60/hour`                                                                                        |
+| `limits.authRatelimit.ipv4Mask`            | Sets the `AUTH_RATELIMIT_IP_V4_MASK` environment variable in the `admin` pod                                                           | `24`                                                                                             |
+| `limits.authRatelimit.ipv6Mask`            | Sets the `AUTH_RATELIMIT_IP_V6_MASK` environment variable in the `admin` pod                                                           | `56`                                                                                             |
+| `limits.authRatelimit.user`                | Sets the `AUTH_RATELIMIT_USER` environment variable in the `admin` pod                                                                 | `100/day`                                                                                        |
+| `limits.authRatelimit.exemptionLength`     | Sets the `AUTH_RATELIMIT_EXEMPTION_LENGTH` environment variable in the `admin` pod                                                     | `86400`                                                                                          |
+| `limits.authRatelimit.exemption`           | Sets the `AUTH_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                            | `""`                                                                                             |
+| `limits.messageRatelimit.value`            | Sets the `MESSAGE_RATELIMIT` environment variable in the `admin` pod                                                                   | `200/day`                                                                                        |
+| `limits.messageRatelimit.exemption`        | Sets the `MESSAGE_RATELIMIT_EXEMPTION` environment variable in the `admin` pod                                                         | `""`                                                                                             |
+| `externalRelay.host`                       | Hostname of the external relay                                                                                                         | `""`                                                                                             |
+| `externalRelay.username`                   | Username for the external relay                                                                                                        | `""`                                                                                             |
+| `externalRelay.password`                   | Password for the external relay                                                                                                        | `""`                                                                                             |
+| `externalRelay.existingSecret`             | Name of the secret containing the username and password for the external relay; if set, username and password will be ignored          | `""`                                                                                             |
+| `externalRelay.usernameKey`                | Key in the secret containing the username for the external relay                                                                       | `relay-username`                                                                                 |
+| `externalRelay.passwordKey`                | Key in the secret containing the password for the external relay                                                                       | `relay-password`                                                                                 |
+| `externalRelay.networks`                   | List of networks that are allowed to use Mailu as external relay                                                                       | `[]`                                                                                             |
+| `clusterDomain`                            | Kubernetes cluster domain name                                                                                                         | `cluster.local`                                                                                  |
+| `credentialRounds`                         | Number of rounds to use for password hashing                                                                                           | `12`                                                                                             |
+| `sessionCookieSecure`                      | Controls the secure flag on the cookies of the administrative interface.                                                               | `true`                                                                                           |
+| `sessionTimeout`                           | Maximum amount of time in seconds between requests before a session is invalidated                                                     | `3600`                                                                                           |
+| `permanentSessionLifetime`                 | Maximum amount of time in seconds a session can be kept alive for if it hasn’t timed-out                                               | `108000`                                                                                         |
+| `letsencryptShortchain`                    | Controls whether we send the ISRG Root X1 certificate in TLS handshakes.                                                               | `false`                                                                                          |
+| `customization.siteName`                   | Website name                                                                                                                           | `Mailu`                                                                                          |
+| `customization.website`                    | URL of the website                                                                                                                     | `https://mailu.io`                                                                               |
+| `customization.logoUrl`                    | Sets a URL for a custom logo. This logo replaces the Mailu logo in the topleft of the main admin interface.                            | `none`                                                                                           |
+| `customization.logoBackground`             | Sets a custom background colour for the brand logo in the top left of the main admin interface.                                        | `none`                                                                                           |
+| `welcomeMessage.enabled`                   | Enable welcome message                                                                                                                 | `true`                                                                                           |
+| `welcomeMessage.subject`                   | Subject of the welcome message                                                                                                         | `Welcome to Mailu`                                                                               |
+| `welcomeMessage.body`                      | Body of the welcome message                                                                                                            | `Welcome to Mailu, your new email service. Please change your password and update your profile.` |
+
 
 ### Storage parameters
 
@@ -233,6 +249,7 @@ Check that the deployed pods are all running.
 | `persistence.storageClass`                          | Storage class of backing PVC (for single PVC)                                                                                                                                                             | `""`                   |
 | `persistence.claimNameOverride`                     | Override the name of the PVC (for single PVC)                                                                                                                                                             | `""`                   |
 
+
 ### Ingress settings
 
 | Name                        | Description                                                                                                                      | Value                    |
@@ -254,6 +271,7 @@ Check that the deployed pods are all running.
 | `ingress.realIpHeader`      | Sets the value of `REAL_IP_HEADER` environment variable in the `front` pod                                                       | `X-Forwarded-For`        |
 | `ingress.realIpFrom`        | Sets the value of `REAL_IP_FROM` environment variable in the `front` pod                                                         | `0.0.0.0/0`              |
 | `ingress.tlsFlavorOverride` | Overrides the value of `TLS_FLAVOR` environment variable in the `front` pod                                                      | `""`                     |
+
 
 ### Frontend load balancer for non-HTTP(s) services
 
@@ -318,10 +336,13 @@ Check that the deployed pods are all running.
 | `front.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`            |
 | `front.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`            |
 
+
 ### Admin parameters
 
 | Name                                       | Description                                                                           | Value               |
 | ------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------- |
+| `admin.enabled`                            | Enable access to the admin interface                                                  | `true`              |
+| `admin.uri`                                | URI to access the admin interface                                                     | `/admin`            |
 | `admin.logLevel`                           | Override default log level                                                            | `""`                |
 | `admin.image.repository`                   | Pod image repository                                                                  | `mailu/admin`       |
 | `admin.image.tag`                          | Pod image tag (defaults to mailuVersion)                                              | `""`                |
@@ -371,6 +392,7 @@ Check that the deployed pods are all running.
 | `admin.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `admin.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
+
 ### Redis parameters
 
 | Name                                     | Description                                                         | Value               |
@@ -388,6 +410,7 @@ Check that the deployed pods are all running.
 | `redis.master.persistence.existingClaim` | Pod pvc existing claim; necessary if using single_pvc               | `""`                |
 | `redis.master.persistence.subPath`       | Subpath in PVC; necessary if using single_pvc (set it to `/redis`)  | `""`                |
 | `redis.replica.count`                    | Number of redis replicas (only if `redis.architecture=replication`) | `0`                 |
+
 
 ### Postfix parameters
 
@@ -442,6 +465,7 @@ Check that the deployed pods are all running.
 | `postfix.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `postfix.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 | `postfix.overrides`                          | Enable postfix overrides                                                              | `{}`                |
+
 
 ### Dovecot parameters
 
@@ -500,10 +524,13 @@ Check that the deployed pods are all running.
 | `dovecot.compression`                        | Maildir compression algorithm (gz, bz2, lz4, zstd)                                    | `""`                |
 | `dovecot.compressionLevel`                   | Maildir compression level (1-9)                                                       | `6`                 |
 
+
 ### rspamd parameters
 
 | Name                                        | Description                                                                           | Value               |
 | ------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `rspamd.overrides`                          | Enable rspamd overrides                                                               | `{}`                |
+| `rspamd.antivirusAction`                    | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
 | `rspamd.logLevel`                           | Override default log level                                                            | `""`                |
 | `rspamd.image.repository`                   | Pod image repository                                                                  | `mailu/rspamd`      |
 | `rspamd.image.tag`                          | Pod image tag (defaults to mailuVersion)                                              | `""`                |
@@ -552,7 +579,7 @@ Check that the deployed pods are all running.
 | `rspamd.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
 | `rspamd.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `rspamd.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
-| `rspamd.overrides`                          | Enable rspamd overrides                                                               | `{}`                |
+
 
 ### clamav parameters
 
@@ -611,61 +638,64 @@ Check that the deployed pods are all running.
 | `clamav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `clamav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
+
 ### webmail parameters
 
-| Name                                         | Description                                                                           | Value               |
-| -------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `webmail.enabled`                            | Enable deployment of Roundcube webmail                                                | `true`              |
-| `webmail.uri`                                | URI to access Roundcube webmail                                                       | `/webmail`          |
-| `webmail.type`                               | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`         |
-| `webmail.logLevel`                           | Override default log level                                                            | `""`                |
-| `webmail.image.repository`                   | Pod image repository                                                                  | `mailu/webmail`     |
-| `webmail.image.tag`                          | Pod image tag (defaults to mailuVersion)                                              | `""`                |
-| `webmail.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `webmail.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `webmail.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `webmail.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `webmail.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `webmail.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `webmail.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `webmail.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `webmail.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `webmail.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `webmail.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `webmail.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `webmail.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `webmail.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `webmail.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `webmail.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `webmail.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `webmail.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `webmail.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `webmail.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `webmail.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `webmail.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `webmail.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `webmail.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                 |
-| `webmail.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                 |
-| `webmail.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `webmail.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `webmail.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `webmail.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `webmail.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `webmail.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `webmail.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `webmail.affinity`                           | Affinity for webmail pod assignment                                                   | `{}`                |
-| `webmail.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `webmail.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `webmail.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `webmail.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `webmail.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `webmail.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `webmail.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `webmail.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `webmail.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `webmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `webmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `webmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                         | Description                                                                           | Value                                                                             |
+| -------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `webmail.enabled`                            | Enable deployment of Roundcube webmail                                                | `true`                                                                            |
+| `webmail.uri`                                | URI to access Roundcube webmail                                                       | `/webmail`                                                                        |
+| `webmail.type`                               | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`                                                                       |
+| `webmail.roundcubePlugins`                   | List of Roundcube plugins to enable                                                   | `["archive","zipdownload","markasjunk","managesieve","enigma","carddav","mailu"]` |
+| `webmail.logLevel`                           | Override default log level                                                            | `""`                                                                              |
+| `webmail.image.repository`                   | Pod image repository                                                                  | `mailu/webmail`                                                                   |
+| `webmail.image.tag`                          | Pod image tag (defaults to mailuVersion)                                              | `""`                                                                              |
+| `webmail.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`                                                                    |
+| `webmail.persistence.size`                   | Pod pvc size                                                                          | `20Gi`                                                                            |
+| `webmail.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                                                                              |
+| `webmail.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]`                                                               |
+| `webmail.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                                                                              |
+| `webmail.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                                                                              |
+| `webmail.resources.limits`                   | The resources limits for the container                                                | `{}`                                                                              |
+| `webmail.resources.requests`                 | The requested resources for the container                                             | `{}`                                                                              |
+| `webmail.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`                                                                            |
+| `webmail.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                                                                               |
+| `webmail.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                                                                              |
+| `webmail.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                                                                              |
+| `webmail.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                                                                               |
+| `webmail.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                                                                               |
+| `webmail.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`                                                                            |
+| `webmail.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                                                                              |
+| `webmail.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                                                                              |
+| `webmail.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                                                                               |
+| `webmail.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                                                                               |
+| `webmail.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                                                                               |
+| `webmail.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`                                                                           |
+| `webmail.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                                                                              |
+| `webmail.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                                                                              |
+| `webmail.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                                                                               |
+| `webmail.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                                                                               |
+| `webmail.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                                                                               |
+| `webmail.podLabels`                          | Add extra labels to pod                                                               | `{}`                                                                              |
+| `webmail.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                                                                              |
+| `webmail.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                                                                              |
+| `webmail.initContainers`                     | Add additional init containers to the pod                                             | `[]`                                                                              |
+| `webmail.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                                                                              |
+| `webmail.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                                                                               |
+| `webmail.affinity`                           | Affinity for webmail pod assignment                                                   | `{}`                                                                              |
+| `webmail.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                                                                              |
+| `webmail.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                                                                               |
+| `webmail.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                                                                              |
+| `webmail.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                                                                              |
+| `webmail.service.annotations`                | Admin service annotations                                                             | `{}`                                                                              |
+| `webmail.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                                                                              |
+| `webmail.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`                                                                   |
+| `webmail.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                                                                              |
+| `webmail.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                                                                              |
+| `webmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                                                                              |
+| `webmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                                                                              |
+| `webmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                                                                              |
+
 
 ### webdav parameters
 
@@ -721,6 +751,7 @@ Check that the deployed pods are all running.
 | `webdav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `webdav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
+
 ### fetchmail parameters
 
 | Name                                           | Description                                                                           | Value               |
@@ -775,6 +806,7 @@ Check that the deployed pods are all running.
 | `fetchmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
 | `fetchmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
 | `fetchmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+
 
 ## Example values.yaml to get started
 

--- a/mailu/templates/_secrets.tpl
+++ b/mailu/templates/_secrets.tpl
@@ -74,6 +74,7 @@
       name: {{ include "mailu.database.roundcube.secretName" . }}
       key: {{ include "mailu.database.roundcube.secretKey" . }}
 {{- end }}
+{{- if and .Values.externalRelay.host (not .Values.externalRelay.existingSecret) }}
 - name: RELAYUSER
   valueFrom:
     secretKeyRef:
@@ -84,4 +85,5 @@
     secretKeyRef:
       name: {{ include "mailu.externalRelay.secretName" . }}
       key: {{ .Values.externalRelay.passwordKey }}
+{{- end }}
 {{- end -}}

--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -79,112 +79,13 @@ spec:
               value: {{ default .Values.logLevel .Values.admin.logLevel }}
             - name: QUOTA_STORAGE_URL
               value: {{ printf "redis://%s:%s/%s" (include "mailu.redis.serviceFqdn" .) (include "mailu.redis.port" .) (include "mailu.redis.db.adminQuota" .) }}
-            - name: RATELIMIT_STORAGE_URL
-              value: {{ printf "redis://%s:%s/%s" (include "mailu.redis.serviceFqdn" .) (include "mailu.redis.port" .) (include "mailu.redis.db.rateLimit" .) }}
-            - name: POSTMASTER
-              value: {{ default "postmaster" .Values.postmaster }}
-            - name: DOMAIN
-              value: "{{ required "'domain' needs to be set" .Values.domain }}"
-            - name: HOSTNAMES
-              value: "{{ join "," .Values.hostnames }}"
-            - name: IMAP_ADDRESS
-              value: {{ include "mailu.dovecot.serviceFqdn" . }}
-            - name: POP3_ADDRESS
-              value: {{ include "mailu.dovecot.serviceFqdn" . }}
-            - name: SMTP_ADDRESS
-              value: {{ include "mailu.postfix.serviceFqdn" . }}
-            - name: AUTHSMTP_ADDRESS
-              value: {{ include "mailu.postfix.serviceFqdn" . }}
-            - name: REDIS_ADDRESS
-              value: {{ include "mailu.redis.serviceFqdn" . }}
-            {{- if .Values.webmail.enabled }}
-            - name: WEBMAIL
-              value: {{ .Values.webmail.type | quote }}
-            - name: WEB_WEBMAIL
-              value: {{ required "webmail.uri" .Values.webmail.uri }}
-            - name: WEBMAIL_ADDRESS
-              value: {{ include "mailu.webmail.serviceFqdn" . }}
-            {{- else }}
-            - name: WEBMAIL
-              value: none
-            - name: WEBMAIL_ADDRESS
-              value: localhost
-            - name: WEB_WEBMAIL
-              value: /
-            {{- end }}
-            - name: FRONT_ADDRESS
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            - name: RECIPIENT_DELIMITER
-              value: +
-            - name: SUBNET
-              value: {{ .Values.subnet }}
-            - name: CREDENTIAL_ROUNDS
-              value: {{ .Values.credentialRounds | quote }}
-            - name: SESSION_COOKIE_SECURE
-              value: {{ .Values.sessionCookieSecure | quote }}
-            - name: SESSION_TIMEOUT
-              value: {{ .Values.sessionTimeout | quote }}
-            - name: PERMANENT_SESSION_LIFETIME
-              value: {{ .Values.permanentSessionLifetime | quote }}
-            - name: LETSENCRYPT_SHORTCHAIN
-              value: {{ .Values.letsencryptShortchain | quote }}
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mailu.secretName" . }}
-                  key: secret-key
-            - name: MESSAGE_RATELIMIT
-              value: "{{ required "limits.messageRatelimit.value" .Values.limits.messageRatelimit.value }}"
-            - name: MESSAGE_RATELIMIT_EXEMPTION
-              value: "{{ default "" .Values.limits.messageRatelimit.exemption }}"
-            - name: AUTH_RATELIMIT_IP
-              value: "{{ required "limits.authRatelimit.ip" .Values.limits.authRatelimit.ip }}"
-            - name: AUTH_RATELIMIT_IP_V4_MASK
-              value: "{{ required "limits.authRatelimit.ipv4Mask" .Values.limits.authRatelimit.ipv4Mask }}"
-            - name: AUTH_RATELIMIT_IP_V6_MASK
-              value: "{{ required "limits.authRatelimit.ipv6Mask" .Values.limits.authRatelimit.ipv6Mask }}"
-            - name: AUTH_RATELIMIT_USER
-              value: "{{ required "limits.authRatelimit.user" .Values.limits.authRatelimit.user }}"
-            - name: AUTH_RATELIMIT_EXEMPTION_LENGTH
-              value: "{{ required "limits.authRatelimit.exemptionLength" .Values.limits.authRatelimit.exemptionLength }}"
-            - name: AUTH_RATELIMIT_EXEMPTION
-              value: "{{ default "" .Values.limits.authRatelimit.exemption }}"
-            {{- if .Values.initialAccount.enabled }}
-            - name: INITIAL_ADMIN_MODE
-              value: {{ .Values.initialAccount.mode }}
-            - name: INITIAL_ADMIN_ACCOUNT
-              value: {{ required "'initialAccount.username' needs to be set if 'initialAccount' is used." .Values.initialAccount.username }}
-            - name: INITIAL_ADMIN_DOMAIN
-              value: {{ required "'initialAccount.domain' needs to be set if 'initialAccount' is used." .Values.initialAccount.domain }}
-            - name: INITIAL_ADMIN_PW
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "mailu.initialAccount.secretName" . }}
-                  key: {{ include "mailu.initialAccount.secretKey" . }}
-            {{- end }}
-            - name: DB_FLAVOR
-              value: {{ include "mailu.database.type" .}}
-            {{- if not (eq (include "mailu.database.type" .) "sqlite") }}
-            - name: DB_USER
-              value: {{ include "mailu.database.username" . }}
-            - name: DB_PW
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "mailu.database.secretName" . }}
-                  key: {{ include "mailu.database.secretKey" . }}
-            - name: DB_HOST
-              value: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
-            - name: DB_NAME
-              value: {{ include "mailu.database.name" . }}
-            {{- end }}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.admin.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.admin.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.admin.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.admin.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/clamav/statefulset.yaml
+++ b/mailu/templates/clamav/statefulset.yaml
@@ -76,14 +76,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.clamav.logLevel }}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.clamav.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.clamav.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.clamav.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.clamav.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -82,39 +82,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.dovecot.logLevel }}
-            - name: FRONT_ADDRESS
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            - name: ADMIN_ADDRESS
-              value: {{ include "mailu.admin.serviceFqdn" . }}
-            - name: ANTISPAM_WEBUI_ADDRESS
-              value: {{ printf "%s:11334" (include "mailu.rspamd.serviceFqdn" .) }}
-            - name: POSTMASTER
-              value: {{ default "postmaster" .Values.postmaster }}
-            - name: DOMAIN
-              value: {{ include "mailu.domain" . }}
-            - name: HOSTNAMES
-              value: "{{ join "," .Values.hostnames }}"
-            - name: RECIPIENT_DELIMITER
-              value: +
-            - name: COMPRESSION
-              value: {{ .Values.dovecot.compression | quote }}
-            - name: COMPRESSION_LEVEL
-              value: {{ .Values.dovecot.compressionLevel | quote }}
-            - name: WEBMAIL
-              value: none
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mailu.secretName" . }}
-                  key: secret-key
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.dovecot.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.dovecot.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.dovecot.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.dovecot.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -75,7 +75,7 @@ data:
   ROUNDCUBE_DB_FLAVOR: {{ include "mailu.database.type" . }}
   # SECRET_KEY => via secret
   SESSION_COOKIE_SECURE: {{ .Values.sessionCookieSecure | quote }}
-  SESSION_KEY_BITS: "128"
+  SESSION_KEY_BITS: 128
   SESSION_TIMEOUT: {{ .Values.sessionTimeout | quote }}
   SITENAME: {{ .Values.customization.siteName | quote }}
   SQLALCHEMY_DATABASE_URI: "sqlite:////data/main.db"

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -75,7 +75,7 @@ data:
   ROUNDCUBE_DB_FLAVOR: {{ include "mailu.database.type" . }}
   # SECRET_KEY => via secret
   SESSION_COOKIE_SECURE: {{ .Values.sessionCookieSecure | quote }}
-  SESSION_KEY_BITS: 128
+  # SESSION_KEY_BITS: 128 # TODO: Fix Mailu to parse int when from string
   SESSION_TIMEOUT: {{ .Values.sessionTimeout | quote }}
   SITENAME: {{ .Values.customization.siteName | quote }}
   SQLALCHEMY_DATABASE_URI: "sqlite:////data/main.db"

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  ADMIN: {{ .Values.admin.enabled | quote }}
+  ANTIVIRUS_ACTION: {{ .Values.rspamd.antivirusAction | quote }}
+  AUTH_RATELIMIT_EXEMPTION_LENGTH: {{ .Values.limits.authRatelimit.exemptionLength | quote }}
+  AUTH_RATELIMIT_EXEMPTION: {{ .Values.limits.authRatelimit.exemption | quote }}
+  AUTH_RATELIMIT_IP_V4_MASK: {{ .Values.limits.authRatelimit.ipv4Mask | quote }}
+  AUTH_RATELIMIT_IP_V6_MASK: {{ .Values.limits.authRatelimit.ipv6Mask | quote }}
+  AUTH_RATELIMIT_IP: {{ .Values.limits.authRatelimit.ip | quote  }}
+  AUTH_RATELIMIT_USER: {{ .Values.limits.authRatelimit.user | quote  }}
+  BABEL_DEFAULT_LOCALE: "en"
+  BABEL_DEFAULT_TIMEZONE: "UTC"
+  BOOTSTRAP_SERVE_LOCAL: "true"
+  COMPRESSION_LEVEL: {{ .Values.dovecot.compressionLevel | quote }}
+  COMPRESSION: {{ .Values.dovecot.compression | quote }}
+  CREDENTIAL_ROUNDS: {{ .Values.credentialRounds | quote }}
+  DB_FLAVOR: {{ include "mailu.database.type" . }}
+  DB_HOST: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
+  DB_NAME: {{ include "mailu.database.name" . }}
+  # DB_PW => via secret
+  DB_USER: {{ include "mailu.database.username" . }}
+  DEBUG_ASSETS: ""
+  DEBUG: "false"
+  DEBUG_PROFILER: "false"
+  DEBUG_TB_INTERCEPT_REDIRECTS: "false"
+  DEFAULT_QUOTA: "1000000000"
+  DEFAULT_SPAM_THRESHOLD: "80"
+  DEFER_ON_TLS_ERROR: "true"
+  DISABLE_STATISTICS: "false"
+  DKIM_PATH: "/dkim/{domain}.{selector}.key"
+  DKIM_SELECTOR: "dkim"
+  DMARC_RUA: {{ .Values.dmarc.rua | quote }}
+  DMARC_RUF: {{ .Values.dmarc.ruf | quote }}
+  DOMAIN_REGISTRATION: "false"
+  DOMAIN: {{ .Values.domain | quote }}
+  FETCHMAIL_DELAY: {{ .Values.fetchmail.delay | quote }}
+  FETCHMAIL_ENABLED: {{ .Values.fetchmail.enabled | quote }}
+  HOSTNAMES: {{ join "," .Values.hostnames }}
+  INBOUND_TLS_ENFORCE: "false"
+  INSTANCE_ID_PATH: "/data/instance"
+  KUBERNETES_INGRESS: {{ .Values.ingress.enabled | quote }}
+  LETSENCRYPT_SHORTCHAIN: {{ .Values.letsencryptShortchain | quote }}
+  LOG_LEVEL: {{ .Values.logLevel | quote }}
+  LOGO_BACKGROUND: {{ .Values.customization.logoBackground | quote }}
+  LOGO_URL: {{ .Values.customization.logoUrl | quote }}
+  MEMORY_SESSIONS: "false"
+  MESSAGE_RATELIMIT_EXEMPTION: {{ .Values.limits.messageRatelimit.exemption | quote }}
+  MESSAGE_RATELIMIT: {{ .Values.limits.messageRatelimit.value | quote  }}
+  MESSAGE_SIZE_LIMIT: "{{ mul .Values.limits.messageSizeLimitInMegabytes (mul 1024 1024) }}"
+  PERMANENT_SESSION_LIFETIME: {{ .Values.permanentSessionLifetime | quote }}
+  POSTMASTER: {{ .Values.postmaster | quote }}
+  PROXY_AUTH_CREATE: "false"
+  PROXY_AUTH_HEADER: "X-Auth-Email"
+  PROXY_AUTH_WHITELIST: ""
+  RATELIMIT_STORAGE_URL: {{ printf "redis://%s:%s/%s" (include "mailu.redis.serviceFqdn" .) (include "mailu.redis.port" .) (include "mailu.redis.db.rateLimit" .) }}
+  REAL_IP_FROM: {{ .Values.ingress.realIpFrom | quote }}
+  REAL_IP_HEADER: {{ .Values.ingress.realIpHeader | quote }}
+  RECAPTCHA_PRIVATE_KEY: ""
+  RECAPTCHA_PUBLIC_KEY: ""
+  RECIPIENT_DELIMITER: {{ .Values.recipientDelimiter | quote }}
+  REJECT_UNLISTED_RECIPIENT: "yes"
+  RELAYHOST: {{ .Values.externalRelay.host | quote }}
+  RELAYNETS: {{ (join "," .Values.externalRelay.networks) | quote }}
+  ROUNDCUBE_DB_FLAVOR: {{ include "mailu.database.type" . }}
+  # SECRET_KEY => via secret
+  SESSION_COOKIE_SECURE: {{ .Values.sessionCookieSecure | quote }}
+  SESSION_KEY_BITS: "128"
+  SESSION_TIMEOUT: {{ .Values.sessionTimeout | quote }}
+  SITENAME: {{ .Values.customization.siteName | quote }}
+  SQLALCHEMY_DATABASE_URI: "sqlite:////data/main.db"
+  SQLALCHEMY_TRACK_MODIFICATIONS: "false"
+  SQLITE_DATABASE_FILE: "data/main.db"
+  STATS_ENDPOINT: "19.{}.stats.mailu.io"
+  SUBNET6: {{ .Values.subnet6 | quote }}
+  SUBNET: {{ .Values.subnet | quote }}
+  TEMPLATES_AUTO_RELOAD: "true"
+  TLS_FLAVOR: {{ include "mailu.tlsFlavor" . }}
+  TLS_PERMISSIVE: "true"
+  TZ: {{ .Values.timezone | quote }}
+  WEB_ADMIN: {{ .Values.admin.uri | quote }}
+  WEBSITE: {{ .Values.customization.website | quote }}
+  WELCOME_BODY: {{ .Values.welcomeMessage.body | quote }}
+  WELCOME_SUBJECT: {{ .Values.welcomeMessage.subject | quote }}
+  WELCOME: {{ .Values.welcomeMessage.enabled | quote}}
+  WILDCARD_SENDERS: ""
+
+  # Addresses
+  ADMIN_ADDRESS: {{ include "mailu.admin.serviceFqdn" . }}
+  ANTISPAM_MILTER_ADDRESS: {{ printf "%s:11332" (include "mailu.rspamd.serviceFqdn" .) }}
+  ANTISPAM_WEBUI_ADDRESS: {{ printf "%s:11334" (include "mailu.rspamd.serviceFqdn" .) }}
+  AUTHSMTP_ADDRESS: {{ include "mailu.postfix.serviceFqdn" . }}
+  FRONT_ADDRESS: {{ include "mailu.front.serviceFqdn" . }}
+  IMAP_ADDRESS: {{ include "mailu.dovecot.serviceFqdn" . }}
+  LMTP_ADDRESS: {{ printf "%s:2525" (include "mailu.dovecot.serviceFqdn" .) }}
+  POP3_ADDRESS: {{ include "mailu.dovecot.serviceFqdn" . }}
+  REDIS_ADDRESS: {{ include "mailu.redis.serviceFqdn" . }}
+  SMTP_ADDRESS: {{ include "mailu.postfix.serviceFqdn" . }}
+
+
+{{- if not (eq (include "mailu.database.type" .) "sqlite") }}
+  ROUNDCUBE_DB_USER: {{ include "mailu.database.roundcube.username" . }}
+  ROUNDCUBE_DB_NAME: {{ include "mailu.database.roundcube.name" . }}
+  ROUNDCUBE_DB_HOST: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
+{{- end }}
+
+{{- if .Values.initialAccount.enabled }}
+  INITIAL_ADMIN_MODE: {{ .Values.initialAccount.mode | quote }}
+  INITIAL_ADMIN_ACCOUNT: {{ .Values.initialAccount.username | quote }}
+  INITIAL_ADMIN_DOMAIN: {{ .Values.initialAccount.domain | quote }}
+{{- end }}
+
+{{- if .Values.webmail.enabled }}
+  WEBMAIL: {{ .Values.webmail.type | quote }}
+  WEB_WEBMAIL: {{ .Values.webmail.uri | quote }}
+  WEBMAIL_ADDRESS: {{ include "mailu.webmail.serviceFqdn" . }}
+  WEBROOT_REDIRECT: {{ .Values.webmail.uri | quote }}
+  ROUNDCUBE_PLUGINS: {{ (join "," .Values.webmail.roundcubePlugins) | quote }}
+{{- else }}
+  WEBMAIL: none
+  WEBMAIL_ADDRESS: localhost
+  WEB_WEBMAIL: /
+  WEBROOT_REDIRECT: /admin/
+{{- end }}
+
+{{- if .Values.webdav.enabled }}
+  WEBDAV: radicale
+  WEBDAV_ADDRESS: {{ include "mailu.webdav.serviceFqdn" . }}
+{{- else }}
+  WEBDAV: none
+  WEBDAV_ADDRESS: localhost
+{{- end }}
+
+{{- if .Values.clamav.enabled }}
+  ANTIVIRUS: clamav
+  ANTIVIRUS_ADDRESS: {{ printf "%s:3310" (include "mailu.clamav.serviceFqdn" .) }}
+{{- else }}
+  ANTIVIRUS: none
+  ANTIVIRUS_ADDRESS: localhost
+{{- end }}

--- a/mailu/templates/fetchmail/deployment.yaml
+++ b/mailu/templates/fetchmail/deployment.yaml
@@ -79,20 +79,13 @@ spec:
               {{- else }}
               value: "False"
               {{- end }}
-            - name: HOST_SMTP
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            - name: HOST_ADMIN
-              value: {{ include "mailu.admin.serviceFqdn" . }}
-            - name: FETCHMAIL_DELAY
-              value: "{{ .Values.fetchmail.delay }}"
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.fetchmail.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.fetchmail.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.fetchmail.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.fetchmail.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/front/deployment.yaml
+++ b/mailu/templates/front/deployment.yaml
@@ -78,71 +78,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.front.logLevel }}
-            - name: KUBERNETES_INGRESS
-              value: "{{ .Values.ingress.enabled }}"
-            - name: TLS_FLAVOR
-              value: {{ include "mailu.tlsFlavor" . }}
-            - name: HOSTNAMES
-              value: "{{ join "," .Values.hostnames }}"
-            - name: ADMIN_ADDRESS
-              value: {{ include "mailu.admin.serviceFqdn" . }}
-            - name: ANTISPAM_WEBUI_ADDRESS
-              value: {{ include "mailu.rspamd.serviceFqdn" . }}:11334
-            - name: POSTMASTER
-              value: {{ default "postmaster" .Values.postmaster }}
-            - name: DOMAIN
-              value: "{{ required "domain" .Values.domain }}"
-            {{- if .Values.ingress.realIpHeader }}
-            - name: REAL_IP_HEADER
-              value: {{ .Values.ingress.realIpHeader }}
-            - name: REAL_IP_FROM
-              value: {{ default "0.0.0.0/0" .Values.ingress.realIpFrom }}
-            {{- end }}
-            {{- if .Values.webmail.enabled }}
-            - name: WEBMAIL
-              value: {{ .Values.webmail.type | quote }}
-            - name: WEBMAIL_ADDRESS
-              value: {{ include "mailu.webmail.serviceFqdn" . }}
-            - name: WEB_WEBMAIL
-              value: {{ required "webmail.uri" .Values.webmail.uri }}
-            - name: WEBROOT_REDIRECT
-              value: {{ required "webmail.uri" .Values.webmail.uri }}
-            {{- else }}
-            - name: WEBMAIL
-              value: none
-            - name: WEBMAIL_ADDRESS
-              value: localhost
-            - name: WEB_WEBMAIL
-              value: ""
-            - name: WEBROOT_REDIRECT
-              value: /admin/
-            {{- end }}
-            - name: MESSAGE_SIZE_LIMIT
-              value: "{{ mul .Values.limits.messageSizeLimitInMegabytes (mul 1024 1024) }}"
-            - name: WEBDAV
-              value: none
-            - name: WEBDAV_ADDRESS
-              value: localhost
-            - name: ADMIN
-              value: "true"
-            - name: WEB_ADMIN
-              value: "/admin"
-            {{- if .Values.webdav.enabled }}
-            - name: WEBDAV
-              value: radicale
-            - name: WEBDAV_ADDRESS
-              value: {{ include "mailu.webdav.serviceFqdn" . }}:5232
-            {{- end }}
-            - name: SUBNET
-              value: {{ .Values.subnet }}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.front.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.front.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.front.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.front.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -78,55 +78,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.postfix.logLevel }}
-            - name: REJECT_UNLISTED_RECIPIENT
-              value: "yes"
-            - name: DOMAIN
-              value: "{{ required "domain" .Values.domain }}"
-            - name: HOSTNAMES
-              value: "{{ join "," .Values.hostnames }}"
-            - name: MESSAGE_SIZE_LIMIT
-              value: "{{ mul .Values.limits.messageSizeLimitInMegabytes (mul 1024 1024) }}"
-            - name: SUBNET
-              value: "{{ .Values.subnet }}"
-            - name: RECIPIENT_DELIMITER
-              value: "+"
-            - name: LMTP_ADDRESS
-              value: {{ include "mailu.dovecot.serviceFqdn" . }}:2525
-            - name: ANTISPAM_MILTER_ADDRESS
-              value: {{ include "mailu.rspamd.serviceFqdn" . }}:11332
-            - name: ADMIN_ADDRESS
-              value: {{ include "mailu.admin.serviceFqdn" . }}
-            - name: FRONT_ADDRESS
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            {{ if .Values.external_relay.host }}
-            - name: RELAYHOST
-              value: "{{ .Values.external_relay.host }}"
-            {{ if .Values.external_relay.secretName }}
-            - name: RELAYUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.external_relay.secretName }}
-                  key: {{ .Values.external_relay.usernameKey}}
-            - name: RELAYPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.external_relay.secretName }}
-                  key: {{ .Values.external_relay.passwordKey }}
-            {{ else if .Values.external_relay.username }}
-            - name: RELAYUSER
-              value: "{{ .Values.external_relay.username }}"
-            - name: RELAYPASSWORD
-              value: "{{ .Values.external_relay.password }}"
-            {{- end}}
-            {{- end}}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.postfix.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.postfix.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.postfix.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.postfix.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -82,33 +82,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.rspamd.logLevel }}
-            - name: FRONT_ADDRESS
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            - name: ADMIN_ADDRESS
-              value: {{ include "mailu.admin.serviceFqdn" . }}
-            - name: REDIS_ADDRESS
-              value: {{ printf "%s:%s" (include "mailu.redis.serviceFqdn" .) (include "mailu.redis.port" .) }}
-            {{- if .Values.clamav.enabled }}
-            - name: ANTIVIRUS
-              value: clamav
-            - name: ANTIVIRUS_ADDRESS
-              value: {{ include "mailu.clamav.serviceFqdn" . }}:3310
-            {{- else }}
-            - name: ANTIVIRUS
-              value: none
-            - name: ANTIVIRUS_ADDRESS
-              value: localhost
-            {{- end }}
-            - name: SUBNET
-              value: "{{ .Values.subnet }}"
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.rspamd.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.rspamd.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.rspamd.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.rspamd.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/secret-external-relay.yaml
+++ b/mailu/templates/secret-external-relay.yaml
@@ -1,0 +1,19 @@
+---
+{{- if and .Values.externalRelay.host (not .Values.externalRelay.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mailu.externalRelay.secretName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" . ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ .Values.externalRelay.usernameKey -}}: {{ (include "mailu.externalRelay.username" . ) | toString | b64enc | quote }}
+  {{ .Values.externalRelay.passwordKey -}}: {{ (include "mailu.externalRelay.password" . ) | toString | b64enc | quote }}
+{{- end }}

--- a/mailu/templates/webdav/deployment.yaml
+++ b/mailu/templates/webdav/deployment.yaml
@@ -73,16 +73,15 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           env:
-            # - name: LOG_LEVEL
-            #   value: {{ default .Values.logLevel .Values.webdav.logLevel }}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            - name: LOG_LEVEL
+              value: {{ default .Values.logLevel .Values.webdav.logLevel }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.webdav.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.webdav.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.webdav.extraEnvVarsCM "context" $) }}

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -75,48 +75,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: {{ default .Values.logLevel .Values.webmail.logLevel }}
-            - name: MESSAGE_SIZE_LIMIT
-              value: "{{ mul .Values.limits.messageSizeLimitInMegabytes (mul 1024 1024) }}"
-            - name: IMAP_ADDRESS
-              value: {{ include "mailu.dovecot.serviceFqdn" . }}
-            - name: FRONT_ADDRESS
-              value: {{ include "mailu.front.serviceFqdn" . }}
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mailu.secretName" . }}
-                  key: secret-key
-            - name: SUBNET
-              value: {{ .Values.subnet }}
-            - name: ADMIN
-              value: "true"
-            - name: WEBMAIL
-              value: {{ .Values.webmail.type | quote }}
-            - name: WEB_ADMIN
-              value: "/admin/"
-            - name: ROUNDCUBE_DB_FLAVOR
-              value: {{ include "mailu.database.type" . }}
-            {{- if not (eq (include "mailu.database.type" .) "sqlite") }}
-            - name: ROUNDCUBE_DB_USER
-              value: {{ include "mailu.database.roundcube.username" . }}
-            - name: ROUNDCUBE_DB_PW
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "mailu.database.roundcube.secretName" . }}
-                  key: {{ include "mailu.database.roundcube.secretKey" . }}
-            - name: ROUNDCUBE_DB_NAME
-              value: {{ include "mailu.database.roundcube.name" . }}
-            - name: ROUNDCUBE_DB_HOST
-              value: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
-            {{- end }}
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: {{ .Values.timezone }}
-            {{- end }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
             {{- if .Values.webmail.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.webmail.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.webmail.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.webmail.extraEnvVarsCM "context" $) }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -36,6 +36,14 @@ commonLabels: {}
 ## @param commonAnnotations Add annotations to all the deployed resources
 commonAnnotations: {}
 
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## @param tolerations Tolerations for pod assignment
+tolerations: []
+
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## @param affinity Affinity for pod assignment
+affinity: {}
+
 ## @section Mailu parameters
 
 ## e.g.:
@@ -62,6 +70,9 @@ secretKey: ""
 ## The secret has to contain the secretKey value under the `secret-key` key.
 existingSecret: ""
 
+## @param timezone Timezone to use for the containers
+timezone: "Etc/UTC"
+
 ## e.g.:
 ## initialAccount:
 ##   username: mailadmin
@@ -85,8 +96,11 @@ initialAccount:
   existingSecretPasswordKey: ""
   mode: "update"
 
-## @param subnet Change this if you're using different address ranges for pods
+## @param subnet Change this if you're using different address ranges for pods (IPv4)
 subnet: 10.42.0.0/16
+
+## @param subnet6 Change this if you're using different address ranges for pods (IPv6)
+subnet6: "none"
 
 ## @param networkPolicy.enabled Enable network policy
 networkPolicy:
@@ -100,6 +114,15 @@ logLevel: WARNING
 
 ## @param postmaster local part of the postmaster email address (Mailu will use @$DOMAIN as domain part)
 postmaster: postmaster
+
+## @param recipientDelimiter The delimiter used to separate local part from extension in recipient addresses
+recipientDelimiter: "+"
+
+## @param dmarc.rua Local part of the DMARC report email address (Mailu will use @$DOMAIN as domain part)
+## @param dmarc.ruf Local part of the DMARC failure report email address (Mailu will use @$DOMAIN as domain part)
+dmarc:
+  rua: none
+  ruf: none
 
 limits:
   ## @param limits.messageSizeLimitInMegabytes Maximum size of an email in megabytes
@@ -129,27 +152,30 @@ limits:
 
 ## Mailu external relay configuration
 ## Example:
-##  external_relay:
+##  externalRelay:
 ##    host: "[domain.tld]:port"
 ##    username: username
 ##    password: SECRET
 ##    # username and password can also be stored as secret:
-##    secretName: external-relay-secret
+##    existingSecret: external-relay-secret
 ##    usernameKey: username
 ##    passwordKey: password
-## @param external_relay.host Hostname of the external relay
-## @param external_relay.username Username for the external relay
-## @param external_relay.password Password for the external relay
-## @param external_relay.secretName Name of the secret containing the username and password for the external relay; if set, username and password will be ignored
-## @param external_relay.usernameKey Key in the secret containing the username for the external relay
-## @param external_relay.passwordKey Key in the secret containing the password for the external relay
-external_relay:
+##    networks: ["10.0.0.0/24", "2001:db8::/32"]
+## @param externalRelay.host Hostname of the external relay
+## @param externalRelay.username Username for the external relay
+## @param externalRelay.password Password for the external relay
+## @param externalRelay.existingSecret Name of the secret containing the username and password for the external relay; if set, username and password will be ignored
+## @param externalRelay.usernameKey Key in the secret containing the username for the external relay
+## @param externalRelay.passwordKey Key in the secret containing the password for the external relay
+## @param externalRelay.networks List of networks that are allowed to use Mailu as external relay
+externalRelay:
   host: ""
   username: ""
   password: ""
-  secretName: ""
+  existingSecret: ""
   usernameKey: "relay-username"
   passwordKey: "relay-password"
+  networks: []
 
 ## @param clusterDomain Kubernetes cluster domain name
 clusterDomain: cluster.local
@@ -171,15 +197,23 @@ permanentSessionLifetime: 108000
 ## This is required for android handsets older than 7.1.1 but slows down the performance of modern devices.
 letsencryptShortchain: false
 
-## nodeSelector: {}
+## @param customization.siteName Website name
+## @param customization.website URL of the website
+## @param customization.logoUrl Sets a URL for a custom logo. This logo replaces the Mailu logo in the topleft of the main admin interface.
+## @param customization.logoBackground Sets a custom background colour for the brand logo in the top left of the main admin interface.
+customization:
+  siteName: "Mailu"
+  website: "https://mailu.io"
+  logoUrl: "none"
+  logoBackground: "none"
 
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-## @param tolerations Tolerations for pod assignment
-tolerations: []
-
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## @param affinity Affinity for pod assignment
-affinity: {}
+## @param welcomeMessage.enabled Enable welcome message
+## @param welcomeMessage.subject Subject of the welcome message
+## @param welcomeMessage.body Body of the welcome message
+welcomeMessage:
+  enabled: true
+  subject: "Welcome to Mailu"
+  body: "Welcome to Mailu, your new email service. Please change your password and update your profile."
 
 ## @section Storage parameters
 
@@ -760,6 +794,12 @@ front:
 
 ## @section Admin parameters
 admin:
+  ## @param admin.enabled Enable access to the admin interface
+  enabled: true
+
+  ## @param admin.uri URI to access the admin interface
+  uri: /admin
+
   ## @param admin.logLevel Override default log level
   logLevel: ""
 
@@ -1365,6 +1405,19 @@ dovecot:
 
 ## @section rspamd parameters
 rspamd:
+  ## @param rspamd.overrides Enable rspamd overrides
+  ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings
+  ## Example:
+  ## overrides:
+  ##   fileA.conf: |
+  ##     obj {
+  ##       key = value;
+  ##     }
+  overrides: {}
+
+  ## @param rspamd.antivirusAction Action to take when an virus is detected. Possible values: `reject` or `discard`
+  antivirusAction: "discard"
+
   ## @param rspamd.logLevel Override default log level
   logLevel: ""
 
@@ -1541,16 +1594,6 @@ rspamd:
 
   ## @param rspamd.extraVolumes Optionally specify extra list of additional volumes for the pod(s)
   extraVolumes: []
-
-  ## @param rspamd.overrides Enable rspamd overrides
-  ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings
-  ## Example:
-  ## overrides:
-  ##   fileA.conf: |
-  ##     obj {
-  ##       key = value;
-  ##     }
-  overrides: {}
 
 ## @section clamav parameters
 clamav:
@@ -1773,6 +1816,16 @@ webmail:
 
   ## @param webmail.type Type of webmail to deploy (`roundcube` or `snappymail`)
   type: roundcube
+
+  ## @param webmail.roundcubePlugins List of Roundcube plugins to enable
+  roundcubePlugins:
+    - archive
+    - zipdownload
+    - markasjunk
+    - managesieve
+    - enigma
+    - carddav
+    - mailu
 
   ## @param webmail.logLevel Override default log level
   logLevel: ""

--- a/utils/check_env_vars.py
+++ b/utils/check_env_vars.py
@@ -1,0 +1,304 @@
+"""
+This script checks if environments variables from Mailu master branch are all considered in the Helm Chart.
+"""
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+from pprint import pprint
+import re
+
+import requests
+import yaml
+from tabulate import tabulate
+
+
+MAPPING = {
+    # Specific to the admin UI
+    "DOCKER_SOCKET": (False, "Not necessary"),
+    "BABEL_DEFAULT_LOCALE": ("", ""),
+    "BABEL_DEFAULT_TIMEZONE": ("", ""),
+    "BOOTSTRAP_SERVE_LOCAL": ("", ""),
+    "RATELIMIT_STORAGE_URL": (False, "Managed by Helm chart"),
+    "DEBUG": ("", ""),
+    "DEBUG_PROFILER": ("", ""),
+    "DEBUG_TB_INTERCEPT_REDIRECTS": ("", ""),
+    "DEBUG_ASSETS": ("", ""),
+    "DOMAIN_REGISTRATION": ("", ""),
+    "TEMPLATES_AUTO_RELOAD": ("", ""),
+    "MEMORY_SESSIONS": ("", ""),
+    "FETCHMAIL_ENABLED": ("fetchmail.enabled", ""),
+    # Database settings
+    "DB_FLAVOR": (False, "Managed by Helm chart"),
+    "DB_USER": (False, "Managed by Helm chart"),
+    "DB_PW": (False, "Managed by Helm chart"),
+    "DB_HOST": (False, "Managed by Helm chart"),
+    "DB_NAME": (False, "Managed by Helm chart"),
+    "SQLITE_DATABASE_FILE": ("", ""),
+    "SQLALCHEMY_DATABASE_URI": ("", ""),
+    "SQLALCHEMY_TRACK_MODIFICATIONS": ("", ""),
+    # Statistics management
+    "INSTANCE_ID_PATH": ("", ""),
+    "STATS_ENDPOINT": ("", ""),
+    # Common configuration variables
+    "SECRET_KEY": ("", ""),
+    "DOMAIN": ("domain", ""),
+    "HOSTNAMES": ("hostnames", ""),
+    "POSTMASTER": ("postmaster", ""),
+    "WILDCARD_SENDERS": ("", ""),
+    "TLS_FLAVOR": ("ingress.tlsFlavorOverride", ""),
+    "INBOUND_TLS_ENFORCE": ("", ""),
+    "DEFER_ON_TLS_ERROR": ("", ""),
+    "AUTH_RATELIMIT_IP": ("limits.authRatelimit.ip", ""),
+    "AUTH_RATELIMIT_IP_V4_MASK": ("limits.authRatelimit.ipv4Mask", ""),
+    "AUTH_RATELIMIT_IP_V6_MASK": ("limits.authRatelimit.ipv6Mask", ""),
+    "AUTH_RATELIMIT_USER": ("limits.authRatelimit.user", ""),
+    "AUTH_RATELIMIT_EXEMPTION": ("limits.authRatelimit.exemption", ""),
+    "AUTH_RATELIMIT_EXEMPTION_LENGTH": ("limits.authRatelimit.exemptionLength", ""),
+    "DISABLE_STATISTICS": ("", ""),
+    # Mail settings
+    "DMARC_RUA": ("", ""),
+    "DMARC_RUF": ("", ""),
+    "WELCOME": ("", ""),
+    "WELCOME_SUBJECT": ("", ""),
+    "WELCOME_BODY": ("", ""),
+    "DKIM_SELECTOR": ("", ""),
+    "DKIM_PATH": ("", ""),
+    "DEFAULT_QUOTA": ("", ""),
+    "MESSAGE_RATELIMIT": ("limits.messageRatelimit.value", ""),
+    "MESSAGE_RATELIMIT_EXEMPTION": ("limits.messageRatelimit.exemption", ""),
+    "RECIPIENT_DELIMITER": ("", ""),
+    # Web settings
+    "SITENAME": ("", ""),
+    "WEBSITE": ("", ""),
+    "ADMIN": ("", ""),
+    "WEB_ADMIN": ("", ""),
+    "WEB_WEBMAIL": ("webmail.uri", ""),
+    "WEBMAIL": ("webmail.type", ""),
+    "RECAPTCHA_PUBLIC_KEY": ("", ""),
+    "RECAPTCHA_PRIVATE_KEY": ("", ""),
+    "LOGO_URL": ("", ""),
+    "LOGO_BACKGROUND": ("", ""),
+    # Advanced settings
+    "LOG_LEVEL": ("logLevel", ""),
+    "SESSION_KEY_BITS": ("", ""),
+    "SESSION_TIMEOUT": ("sessionTimeout", ""),
+    "PERMANENT_SESSION_LIFETIME": ("permanentSessionLifetime", ""),
+    "SESSION_COOKIE_SECURE": ("sessionCookieSecure", ""),
+    "CREDENTIAL_ROUNDS": ("credentialRounds", ""),
+    "TLS_PERMISSIVE": ("", ""),
+    "TZ": ("timezone", ""),
+    "DEFAULT_SPAM_THRESHOLD": ("", ""),
+    "PROXY_AUTH_WHITELIST": ("", ""),
+    "PROXY_AUTH_HEADER": ("", ""),
+    "PROXY_AUTH_CREATE": ("", ""),
+    # Host settings
+    "HOST_IMAP": (False, "Managed by Helm chart"),
+    "HOST_LMTP": (False, "Managed by Helm chart"),
+    "HOST_POP3": (False, "Managed by Helm chart"),
+    "HOST_SMTP": (False, "Managed by Helm chart"),
+    "HOST_AUTHSMTP": (False, "Managed by Helm chart"),
+    "HOST_ADMIN": (False, "Managed by Helm chart"),
+    "HOST_WEBMAIL": (False, "Managed by Helm chart"),
+    "HOST_WEBDAV": (False, "Managed by Helm chart"),
+    "HOST_REDIS": (False, "Managed by Helm chart"),
+    "HOST_FRONT": (False, "Managed by Helm chart"),
+    "SUBNET": ("subnet", ""),
+    "SUBNET6": (False, "Not supported yet by Helm chart"),
+}
+
+
+class EnvVarChecker:
+    """Check if all environment variables are considered in the Helm Chart"""
+
+    def __init__(self, mapping) -> None:
+        self.base_path = os.path.dirname(os.path.abspath(__file__))
+        self.mailu_config_url = "https://raw.githubusercontent.com/Mailu/Mailu/master/core/admin/mailu/configuration.py"
+        self.mailu_config = None
+        self.mapping = mapping
+        self.helm_values = {}
+        self.env_vars = {}
+
+    def get_mailu_config(self):
+        """Get the Mailu configuration file"""
+        # request https://github.com/Mailu/Mailu/raw/master/core/admin/mailu/configuration.py
+        req = requests.get(
+            self.mailu_config_url,
+            timeout=5,
+        )
+        req.raise_for_status()
+
+        self.mailu_config = req.text.splitlines()
+
+        return True
+
+    def get_env_vars_from_mailu(self):
+        """Get the environment variables from the Mailu configuration file"""
+
+        if not self.mailu_config:
+            self.get_mailu_config()
+
+        found = False
+        self.env_vars = {}
+        group = ""
+
+        for line in self.mailu_config:
+            if "DEFAULT_CONFIG" in line:
+                found = True
+                continue
+            if found:
+                # End of DEFAULT_CONFIG
+                if line.startswith("}"):
+                    break
+                # Group
+                if line.strip().startswith("#"):
+                    group = line.strip()[1:].strip()
+                    continue
+
+                name = line.split(": ")[0].strip()
+                if name.startswith("'"):
+                    name = name[1:-1]
+
+                default_value = line.split(": ")[1].strip()
+                if default_value.startswith("'"):
+                    default_value = default_value[1:-1]
+
+                # extract name using regex
+                name_reg = re.findall(
+                    r"'([\w_]+)'\s*:\s*('?)((?:.*[^,])|(?:[^,]*.))\2\s*,?$",
+                    line.strip(),
+                )
+
+                if len(name_reg) != 1:
+                    print(f"ERROR: Cannot extract name/value from line: {line}")
+                    continue
+
+                name = name_reg[0][0]
+                default_value = name_reg[0][2]
+                quoted = name_reg[0][1] == "'" or name_reg[0][1] == '"'
+
+                self.env_vars[name] = {
+                    "group": group,
+                    "name": name,
+                    "default_value": default_value,
+                    "quoted": quoted,
+                    "path": "",
+                    "helm_default_value": "",
+                    "comment": "",
+                }
+
+    def import_helm_values(self):
+        """Import the Helm values.yaml file"""
+        values_file = os.path.join(self.base_path, "..", "mailu", "values.yaml")
+        with open(values_file, "r", encoding="utf-8") as file:
+            self.helm_values = yaml.safe_load(file)
+
+    def get_value(self, path):
+        """Get a value from a nested dict"""
+
+        if len(self.helm_values) == 0:
+            self.import_helm_values()
+
+        value = self.helm_values
+        for key in path.split("."):
+            if key not in value:
+                print(f"ERROR: Missing {path}")
+                return None
+            value = value[key]
+
+        return value
+
+    def check_env_vars(self):
+        """Check if all environment variables are considered in the Helm Chart"""
+        if len(self.env_vars) == 0:
+            self.get_env_vars_from_mailu()
+
+        for (name, env_var) in self.env_vars.items():
+            default_value = env_var["default_value"]
+
+            if name not in self.mapping:
+                env_var["status"] = "missing_mapping"
+                continue
+
+            env_var["comment"] = self.mapping[name][1]
+
+            if self.mapping[name][0] is False:
+                env_var["status"] = "skipped"
+                continue
+
+            if self.mapping[name][0] == "":
+                env_var["status"] = "empty_mapping"
+                continue
+
+            helm_default_value = self.get_value(self.mapping[name][0])
+
+            if helm_default_value is None:
+                env_var["status"] = "missing_helm_value"
+                continue
+
+            env_var["path"] = self.mapping[name][0]
+            env_var["helm_default_value"] = helm_default_value
+
+            if helm_default_value != default_value:
+                env_var["status"] = "default_value_mismatch"
+                continue
+
+            self.env_vars[name]["status"] = "ok"
+
+    def get_grouped_by(self, key):
+        """Get a dict of env vars grouped by a key"""
+        if len(self.env_vars) == 0:
+            self.check_env_vars()
+
+        by_key = {}
+        for (name, env_var) in self.env_vars.items():
+            if env_var[key] not in by_key:
+                by_key[env_var[key]] = {}
+            by_key[env_var[key]][name] = env_var
+
+        return by_key
+
+    def print_status(self):
+        """Print the status of the environment variables"""
+        tabs = []
+        headers = [
+            "Mailu env var",
+            "Helm config path",
+            "Status",
+            "Comment",
+            "Default value",
+            "Helm default value",
+        ]
+        for (status, env_vars) in self.get_grouped_by("status").items():
+            print(f"### {status} ({len(env_vars)}) ###")
+            for (name, env_var) in env_vars.items():
+                tabs.append(
+                    [
+                        name,
+                        env_var["path"],
+                        status,
+                        env_var["comment"],
+                        env_var["default_value"],
+                        env_var["helm_default_value"],
+                    ]
+                )
+
+        print(tabulate(tabs, headers=headers, tablefmt="github"))
+
+    def print_configmap(self):
+        """Print the configmap for the environment variables"""
+
+        for (name, env_var) in self.env_vars.items():
+            if env_var["status"] in ["ok", "default_value_mismatch"]:
+                quoted_str = "| quote " if env_var["quoted"] else ""
+                print(f"{name}: {{{{ .Values.{env_var['path']} {quoted_str} }}}}")
+
+checker = EnvVarChecker(MAPPING)
+checker.check_env_vars()
+if "HOSTNAMES" in checker.env_vars:
+    pprint(checker.env_vars["HOSTNAMES"])
+checker.print_status()
+
+checker.print_configmap()
+
+# for env_var in env_vars:
+#     print(f"env_var: {env_var['name']} {env_var['default_value']} {env_var['quoted']}")

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,1 @@
+tabulate


### PR DESCRIPTION
Mount env vars from configmap and secrets.
Add some missing configuration options to Helm values.

All env vars are now mounted on all pods.